### PR TITLE
use qt_base::Task to fix all threading-related issues w.r.t. Qt usage

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,11 +1,12 @@
 <package>
-  <description brief="">
-  
+  <description brief="Management of a Vizkit3D environment to reflect dynamic position changes">
+      This package implements a base support to update poses and joints of elements in a Vizkit3D
+      world. The goal is to have the world set up and updated, while being able to add Vizkit3D
+      plugins to display extra information (e.g. a laser line, an osgOcean environment, ...)
   </description>
-  <author>/</author>
-  <license></license>
-  <url>http://</url>
-  <logo>http://</logo>
+
+  <license>LGPLv2 or later</license>
   <depend package="base/cmake" />
   <depend package="gui/vizkit3d_world" />
+  <depend package="gui/orogen/qt_base" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -2,16 +2,65 @@
 
 #include "Task.hpp"
 
+using namespace std;
 using namespace vizkit3d_world;
 
-const std::string Task::JOINTS_CMD_POSFIX = ":joints_cmd";
+const string Task::JOINTS_CMD_POSFIX = ":joints_cmd";
 
-Task::Task(std::string const& name) :
+struct MethodInQtThreadFailed : runtime_error {
+    using runtime_error::runtime_error;
+};
+
+struct MethodExecutionEvent : public QEvent {
+    QMutex& mLock;
+    QWaitCondition& mSignal;
+    bool& mResult;
+    string& mMessage;
+
+    MethodExecutionEvent(QMutex& lock, QWaitCondition& signal,
+                         bool& result, string& message)
+        : QEvent(QEvent::User)
+        , mLock(lock), mSignal(signal), mResult(result), mMessage(message) { }
+
+    function<void()> f;
+};
+
+class MethodExecutionObject : public QObject {
+    bool event(QEvent* event) {
+        auto ev = dynamic_cast<MethodExecutionEvent*>(event);
+        if (ev) {
+            try {
+                ev->f();
+
+                QMutexLocker sync(&(ev->mLock));
+                ev->mResult = true;
+                ev->mSignal.wakeAll();
+            }
+            catch (exception const& e) {
+                QMutexLocker sync(&(ev->mLock));
+                ev->mResult = false;
+                ev->mMessage = e.what();
+                ev->mSignal.wakeAll();
+            }
+            catch (...) {
+                QMutexLocker sync(&(ev->mLock));
+                ev->mResult = false;
+                ev->mMessage =
+                    "exception thrown that is not a subclass of exception";
+                ev->mSignal.wakeAll();
+            }
+            return true;
+        }
+        return false;
+    }
+};
+
+Task::Task(string const& name) :
         TaskBase(name)
 {
 }
 
-Task::Task(std::string const& name, RTT::ExecutionEngine* engine) :
+Task::Task(string const& name, RTT::ExecutionEngine* engine) :
         TaskBase(name, engine)
 {
 }
@@ -19,7 +68,106 @@ Task::Task(std::string const& name, RTT::ExecutionEngine* engine) :
 Task::~Task() {
 }
 
-void Task::setupJointsPorts() 
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See Task.hpp for more detailed
+// documentation about them.
+bool Task::configureHook() {
+
+    if (!TaskBase::configureHook()) {
+        return false;
+    }
+
+    //create an instance from Vizkit3dWorld
+    if (_widgets.get() < 1) {
+        throw runtime_error("There must be at least one instance of Vizkit3dWorld");
+    }
+
+    if (!mExecutor) {
+        mExecutor = new MethodExecutionObject();
+        mExecutor->moveToThread(QApplication::instance()->thread());
+    }
+
+    processInQtThread(bind(&Task::configureUI, this));
+
+    //Initialize vizkit3d world
+    //this method initialize a thread with event loop
+    setupJointsPorts();
+
+    return true;
+}
+
+void Task::configureUI() {
+    for (int i = 0; i < _widgets.get(); ++i) {
+        Vizkit3dWorld* vizkit3dWorld = new Vizkit3dWorld(_world_file_path.value(),
+                                        _model_paths.value(),
+                                        _ignored_models.get(),
+                                        _width.get(),
+                                        _height.get(),
+                                        60,
+                                        0.01,
+                                        1000);
+
+        vizkit3dWorlds.push_back(vizkit3dWorld);
+    }
+    vizkit3dWorld = vizkit3dWorlds[0];
+}
+
+bool Task::startHook() {
+
+    if (!TaskBase::startHook()) {
+        return false;
+    }
+
+    processInQtThread(bind(&Task::startUI, this));
+    return true;
+}
+
+void Task::startUI() {
+}
+
+void Task::updateHook() {
+    TaskBase::updateHook();
+
+    processInQtThread(bind(&Task::updateUI, this));
+}
+
+
+void Task::updateUI() {
+    updateJoints();
+    updatePose();
+}
+
+void Task::errorHook() {
+    TaskBase::errorHook();
+}
+
+void Task::errorUI() {
+}
+
+void Task::stopHook() {
+    TaskBase::stopHook();
+    processInQtThread(bind(&Task::stopUI, this));
+}
+
+void Task::stopUI() {
+}
+
+void Task::cleanupHook() {
+    releaseJointsPorts();
+
+    TaskBase::cleanupHook();
+    processInQtThread(bind(&Task::cleanupUI, this));
+}
+
+void Task::cleanupUI() {
+    for (auto vizkit3dWorld: vizkit3dWorlds) {
+        delete vizkit3dWorld;
+        vizkit3dWorld = nullptr;
+    }
+    vizkit3dWorlds.clear();
+}
+
+void Task::setupJointsPorts()
 {
     //get a map with robot models
     vizkit3d_world::RobotVizMap robotVizMap = vizkit3dWorlds[0]->getRobotVizMap();
@@ -31,14 +179,15 @@ void Task::setupJointsPorts()
     {
         //set the joint name
         //joint name is model name concatenate with posfix ":joints_cmd"
-        std::string nameCmd = it->first + JOINTS_CMD_POSFIX;
+        string nameCmd = it->first + JOINTS_CMD_POSFIX;
 
-        RTT::InputPort<base::samples::Joints> *portIn = new RTT::InputPort<base::samples::Joints>(nameCmd);
+        RTT::InputPort<base::samples::Joints>* portIn =
+            new RTT::InputPort<base::samples::Joints>(nameCmd);
 
         //this map stores the original model name and the port name is the key
-        mapModel.insert(std::make_pair(nameCmd, it->first));
+        mapModel.insert(make_pair(nameCmd, it->first));
         //this map stores the input port and the port name is the key
-        mapPorts.insert(std::make_pair(nameCmd, portIn));
+        mapPorts.insert(make_pair(nameCmd, portIn));
 
         ports()->addEventPort(*portIn);
     }
@@ -47,7 +196,7 @@ void Task::setupJointsPorts()
 void Task::releaseJointsPorts(){
 
     //remove ports from task and delete object from memory
-    for (std::map<std::string,  RTT::base::PortInterface*>::iterator it  = mapPorts.begin();
+    for (map<string,  RTT::base::PortInterface*>::iterator it  = mapPorts.begin();
              it != mapPorts.end();
              it++)
     {
@@ -63,20 +212,20 @@ void Task::updateJoints() {
 
     //iterate each model store and update joint state
     //read information from input port and send this information to vizkit3d model
-    for (std::map<std::string, std::string>::iterator it  = mapModel.begin();
+    for (map<string, string>::iterator it  = mapModel.begin();
          it != mapModel.end();
          it++)
     {
 
-        std::string portName = it->first;
-        std::string modelName = it->second;
+        string portName = it->first;
+        string modelName = it->second;
 
-        RTT::InputPort<base::samples::Joints>* jointCmd = dynamic_cast<RTT::InputPort<base::samples::Joints>*>(mapPorts[portName]);
+        RTT::InputPort<base::samples::Joints>* jointCmd =
+            dynamic_cast<RTT::InputPort<base::samples::Joints>*>(mapPorts[portName]);
 
         base::samples::Joints joints;
-        for(auto& vizkit3dWorld : vizkit3dWorlds)
-        {
-            while (jointCmd->readNewest(joints) == RTT::NewData) 
+        for (auto& vizkit3dWorld : vizkit3dWorlds) {
+            while (jointCmd->readNewest(joints) == RTT::NewData)
             {
                 //set joint states
                 vizkit3dWorld->setJoints(modelName, joints);
@@ -85,83 +234,31 @@ void Task::updateJoints() {
     }
 }
 
-
-
 void Task::updatePose() {
     //set model position using vizkit3d transformation
     //read a pose from input port and send perform the transformation
     base::samples::RigidBodyState pose;
-    for(auto& vizkit3dWorld : vizkit3dWorlds)
-    {
+    for (auto& vizkit3dWorld : vizkit3dWorlds) {
         while (_pose_cmd.read(pose) == RTT::NewData) {
             vizkit3dWorld->setTransformation(pose);
         }
     }
 }
 
-/// The following lines are template definitions for the various state machine
-// hooks defined by Orocos::RTT. See Task.hpp for more detailed
-// documentation about them.
-bool Task::configureHook() {
 
-    if (!TaskBase::configureHook())
-        return false;
+void Task::processInQtThread(function<void()> f) {
+    QMutexLocker sync(&mExecutorLock);
 
-    //create an instance from Vizkit3dWorld
-    if(_widgets.get() < 1)
-        throw std::runtime_error("There must be at least one instance of Vizkit3dWorld");
+    bool result = true;
+    string message;
+    auto* event = new MethodExecutionEvent(
+        mExecutorLock, mExecutorSignal, result, message
+    );
+    event->f = f;
+    QApplication::instance()->postEvent(mExecutor, event);
 
-    for(int i = 0; i < _widgets.get(); ++i)
-    {
-        Vizkit3dWorld* vizkit3dWorld = new Vizkit3dWorld(_world_file_path.value(),
-                                        _model_paths.value(),
-                                        _ignored_models.get(),
-                                        _width.get(),
-                                        _height.get(),
-                                        60,
-                                        0.01,
-                                        1000);
-
-        vizkit3dWorlds.push_back(vizkit3dWorld);                                
+    mExecutorSignal.wait(&mExecutorLock);
+    if (!result) {
+        throw MethodInQtThreadFailed(message);
     }
-    vizkit3dWorld = vizkit3dWorlds[0];
-    //Initialize vizkit3d world
-    //this method initialize a thread with event loop
-    setupJointsPorts();
-
-    return true;
 }
-bool Task::startHook() {
-
-    if (!TaskBase::startHook())
-        return false;
-
-    return true;
-}
-
-void Task::updateHook() {
-    TaskBase::updateHook();
-    updateJoints();
-    updatePose();
-}
-
-void Task::errorHook() {
-    TaskBase::errorHook();
-}
-
-void Task::stopHook() {
-    TaskBase::stopHook();
-}
-
-void Task::cleanupHook() {
-    TaskBase::cleanupHook();
-
-    releaseJointsPorts();
-    for(auto vizkit3dWorld: vizkit3dWorlds)
-    {
-        delete vizkit3dWorld;
-        vizkit3dWorld = NULL;
-    }
-    vizkit3dWorlds.clear();
-}
-

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -28,10 +28,6 @@ namespace vizkit3d_world {
 	friend class TaskBase;
 
     private:
-        QObject* mExecutor;
-        QMutex mExecutorLock;
-        QWaitCondition mExecutorSignal;
-
         /**
          * set the posfix
          */
@@ -51,14 +47,12 @@ namespace vizkit3d_world {
         bool showGui;
 
     protected:
-        void processInQtThread(std::function<void()> f);
-
         /**
          * Used to manage the scene in C/C++
          */
-	    std::vector<Vizkit3dWorld*> vizkit3dWorlds;
+        std::vector<Vizkit3dWorld*> vizkit3dWorlds;
         //to maintain backward compatibility
-	    Vizkit3dWorld* vizkit3dWorld;
+        Vizkit3dWorld* vizkit3dWorld;
 
     public:
         /** TaskContext constructor for Task
@@ -103,8 +97,6 @@ namespace vizkit3d_world {
          */
         bool startHook();
 
-        virtual void startUI();
-
         /** This hook is called by Orocos when the component is in the Running
          * state, at each activity step. Here, the activity gives the "ticks"
          * when the hook should be called.
@@ -137,8 +129,6 @@ namespace vizkit3d_world {
          * from Running to Stopped after stop() has been called.
          */
         void stopHook();
-
-        virtual void stopUI();
 
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to PreOperational, requiring the call to configureHook()

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -9,11 +9,11 @@
 
 namespace vizkit3d_world {
 
-    /*! \class Task 
+    /*! \class Task
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
      * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -21,13 +21,16 @@ namespace vizkit3d_world {
          task('custom_task_name','vizkit3d_world::Task')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
      */
     class Task : public TaskBase
     {
 	friend class TaskBase;
 
     private:
+        QObject* mExecutor;
+        QMutex mExecutorLock;
+        QWaitCondition mExecutorSignal;
 
         /**
          * set the posfix
@@ -48,6 +51,7 @@ namespace vizkit3d_world {
         bool showGui;
 
     protected:
+        void processInQtThread(std::function<void()> f);
 
         /**
          * Used to manage the scene in C/C++
@@ -63,10 +67,10 @@ namespace vizkit3d_world {
          */
         Task(std::string const& name = "vizkit3d_world::Task");
 
-        /** TaskContext constructor for Task 
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
-         * 
+        /** TaskContext constructor for Task
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         *
          */
         Task(std::string const& name, RTT::ExecutionEngine* engine);
 
@@ -90,6 +94,8 @@ namespace vizkit3d_world {
          */
         bool configureHook();
 
+        virtual void configureUI();
+
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to Running. If it returns false, then the component will
          * stay in Stopped. Otherwise, it goes into Running and updateHook()
@@ -97,13 +103,15 @@ namespace vizkit3d_world {
          */
         bool startHook();
 
+        virtual void startUI();
+
         /** This hook is called by Orocos when the component is in the Running
          * state, at each activity step. Here, the activity gives the "ticks"
          * when the hook should be called.
          *
          * The error(), exception() and fatal() calls, when called in this hook,
          * allow to get into the associated RunTimeError, Exception and
-         * FatalError states. 
+         * FatalError states.
          *
          * In the first case, updateHook() is still called, and recover() allows
          * you to go back into the Running state.  In the second case, the
@@ -113,6 +121,8 @@ namespace vizkit3d_world {
          */
         void updateHook();
 
+        virtual void updateUI();
+
         /** This hook is called by Orocos when the component is in the
          * RunTimeError state, at each activity step. See the discussion in
          * updateHook() about triggering options.
@@ -121,10 +131,14 @@ namespace vizkit3d_world {
          */
         void errorHook();
 
+        virtual void errorUI();
+
         /** This hook is called by Orocos when the state machine transitions
          * from Running to Stopped after stop() has been called.
          */
         void stopHook();
+
+        virtual void stopUI();
 
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to PreOperational, requiring the call to configureHook()
@@ -132,6 +146,7 @@ namespace vizkit3d_world {
          */
         void cleanupHook();
 
+        virtual void cleanupUI();
 
         /**
          * Create and setup dynamic input ports

--- a/vizkit3d_world.orogen
+++ b/vizkit3d_world.orogen
@@ -7,11 +7,12 @@ using_library "vizkit3d_world"
 
 task_context "Task" do
     needs_configuration
+    needs_global_initializer :qt
 
     # Input ports to update the model's joints. They are created based on the
     # world's model
     dynamic_input_port /:joints_cmd$/, '/base/samples/Joints'
-    
+
     #
     # Paths to resolve the model:// URIs in the world file.
     #
@@ -36,7 +37,7 @@ task_context "Task" do
     # List of models that will be ignored from the camera view
     #
     property("ignored_models", "/std/vector</std/string>")
-    
+
     # Number of widgets allowed for multithread
     #
     property("widgets", "int", 1)

--- a/vizkit3d_world.orogen
+++ b/vizkit3d_world.orogen
@@ -4,8 +4,9 @@ import_types_from "base"
 import_types_from "vizkit3d_worldTypes.hpp"
 
 using_library "vizkit3d_world"
+using_task_library "qt_base"
 
-task_context "Task" do
+task_context "Task", subclasses: 'qt_base::Task' do
     needs_configuration
     needs_global_initializer :qt
 


### PR DESCRIPTION
Qt needs all GUI-related operations to be done in the same thread than the Qt application. The Qt initializer in orogen now creates the Qt application *and* calls exec within a single thread. `qt_base` provides a generic interface to run hook code within said thread.

In my tests, this fixes all initialization and reconfiguration related crashes for https://github.com/rock-gazebo/simulation-orogen-underwater_camera_simulation.

In addition, it allows to start multiple `vizkit3d_world` in the same process, and when doing so allows to share the OSG models (i.e. the actual triangle and texture data), thus dramatically reducing memory usage and initialization times.